### PR TITLE
Fix early stopping counter increment

### DIFF
--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -159,7 +159,8 @@ def train_model(
             best_val_loss = val_loss
             epochs_no_improve = 0
         else:
-            epochs_no_improve += TRAINING["patience"]
+            # increment by 1 epoch since no improvement this round
+            epochs_no_improve += 1
 
         if epochs_no_improve >= early_stop_patience:
             if verbose:


### PR DESCRIPTION
## Summary
- correct early stopping logic in trainer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torchvision')*

------
https://chatgpt.com/codex/tasks/task_e_683f4916ae508327a7407959a02f51ea